### PR TITLE
[TEST]ci: Integrate verify, test and build docs in same workflow

### DIFF
--- a/.github/workflows/consumer_test.yml
+++ b/.github/workflows/consumer_test.yml
@@ -13,10 +13,7 @@
 
 name: Consumer Tests
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
 
 jobs:
   test:
@@ -34,12 +31,46 @@ jobs:
         run: |
           bazel run //:ide_support
 
+      - name: Prepare report directory
+        run: |
+          mkdir -p reports
+
       - name: Run Consumer tests
         run: |
-          .venv_docs/bin/python -m pytest -s -v src/tests/ --repo="$CONSUMER"
+          .venv_docs/bin/python -m pytest -s -v src/tests/ --repo="$CONSUMER" --junitxml="reports/${{ matrix.consumer }}.xml" | tee "reports/${{ matrix.consumer }}.log"
 
         env:
           FORCE_COLOR: "1"
           TERM: xterm-256color
           PYTHONUNBUFFERED: "1"
           CONSUMER: ${{ matrix.consumer }}
+
+      - name: Upload consumer test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-${{ matrix.consumer }}
+          path: reports/
+
+  summarize:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Prepare consumer report directory
+        run: |
+          mkdir -p tests-report
+
+      - name: Download individual consumer reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tests-*
+          path: tests-report
+          merge-multiple: true
+
+      - name: Upload bundled consumer report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-report
+          path: tests-report

--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -1,0 +1,58 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Tests, Verify and Build Docs
+
+permissions:
+  contents: write
+  pages: write
+  pull-requests: write
+  id-token: write
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize] # Allows forks to trigger the docs build
+  push:
+    branches:
+      - main
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  docs-verify:
+    uses: nicu1989/cicd-workflows/.github/workflows/docs-verify.yml@main
+    permissions:
+      pull-requests: write
+      contents: read
+    with:
+      bazel-docs-verify-target: "//:docs_check"
+
+  # This is the user configurable part of the workflow
+  consumer-tests:
+    uses: ./.github/workflows/consumer_test.yml
+    secrets: inherit
+
+  docs-build:
+    # Waits for consumer-tests but run only when docs verification succeeded
+    needs: [docs-verify, consumer-tests]
+    if: ${{ always() && needs.docs-verify.result == 'success' }}
+    uses: nicu1989/cicd-workflows/.github/workflows/docs-build.yml@main
+    permissions:
+      contents: write
+      pages: write
+      pull-requests: write
+      id-token: write
+    with:
+      bazel-target: "//:docs -- --github_user=${{ github.repository_owner }} --github_repo=${{ github.event.repository.name }}"
+      retention-days: 3
+      tests-report-artifact: tests-report

--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -46,7 +46,7 @@ jobs:
     # Waits for consumer-tests but run only when docs verification succeeded
     needs: [docs-verify, consumer-tests]
     if: ${{ always() && needs.docs-verify.result == 'success' }}
-    uses: nicu1989/cicd-workflows/.github/workflows/docs-build.yml@main
+    uses: nicu1989/cicd-workflows/.github/workflows/docs.yml@main
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
Implements DR: 001-test-results-in-workflow

DO NOT MERGE. FOR TESTING PURPOSE ONLY. Identic to https://github.com/eclipse-score/docs-as-code/pull/255 + updated path to action: eclipse-score/cicd-workflows/.github/workflows/docs.yml@nicu1989_verify_build_with_tests_TEST
